### PR TITLE
Remove unused `array-find` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "url": "https://github.com/nygardk/BreakJS"
   },
   "dependencies": {
-    "array-find": "^1.0.0",
     "lodash.find": "^3.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I couldn't find any reference to `someArray.find` anywhere and it looks like `lodash.find` is used instead.
